### PR TITLE
Make temp/dew_point an optional parameter as seems to be common

### DIFF
--- a/lib/metar/parser.rb
+++ b/lib/metar/parser.rb
@@ -308,7 +308,7 @@ module Metar
         @temperature = Metar::Temperature.parse($1)
         @dew_point = Metar::Temperature.parse($2)
       else
-        raise ParseError.new("Expecting temperature/dew point, found '#{ @chunks[0] }' in #{@metar}")
+          @chunks.shift
       end
       temperature_dew_point!
     end


### PR DESCRIPTION
This is a somewhat questionable fix to address the fact many stations seem to omit the temperature and dew_point reading.
