### PR TITLE
Fix Bundler/Capistrano errors by not requiring rake/file_list in gemspec (using Dir.glob instead)

### DIFF
--- a/metar-parser.gemspec
+++ b/metar-parser.gemspec
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.unshift( File.join( File.dirname( __FILE__ ), 'lib' ) )
 require 'metar/version'
-require 'rake/file_list'
 
 Gem::Specification.new do |s|
   s.name          = 'metar-parser'
@@ -20,11 +19,13 @@ Gem::Specification.new do |s|
   s.email         = 'joe.g.yates@gmail.com'
 
   s.files         = ['README.md', 'COPYING', 'Rakefile'] +
-                    Rake::FileList['{bin,lib,spec}/**/*.rb'] +
-                    Rake::FileList['locales/**/*.{rb,yml}']
+                    Dir.glob("{bin,lib,spec}/**/*.rb") +
+                    Dir.glob("locales/**/*.{rb,yml}")
+
   s.require_paths = ['lib']
 
-  s.test_files    = Rake::FileList[ 'spec/**/*_spec.rb' ]
+  s.test_files    = Dir.glob("spec/**/*_spec.rb")
+
 
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'rdoc'


### PR DESCRIPTION
Use Dir[] instead of Rake FileList[].

Before I made this change, I got errors like

 *\* [out :: example.com] There was a LoadError while evaluating metar-parser.gemspec:
 *\* [out :: example.com] no such file to load -- rake/file_list from
 *\* [out :: example.com] /var/www/example.com/shared/bundle/ruby/1.8/bundler/gems/metar-parser-b3a058682c38/metar-parser.gemspec:4

trying to deploy  with capistrano and bundler.

@see "Using .gemspecs as Intended" 
http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/
"…Do not, however, use other libraries or dependencies…"
