### PR TITLE
add proper support for Canadian corrections

### DIFF
--- a/doc/metar_format.md
+++ b/doc/metar_format.md
@@ -14,6 +14,9 @@ The METAR Data Format
   * http://weather.cod.edu/notes/metar.html
   * http://www.met.tamu.edu/class/METAR/metar-pg3.html - incomplete
 
+* Canada
+  * https://www.navcanada.ca/en/Media/Publications/AWS-Guide-EN.pdf
+
 Remarks Codes
 ==============
 * http://www.ncdc.noaa.gov/oa/climate/conversion/swometardecoder.html

--- a/lib/metar/parser.rb
+++ b/lib/metar/parser.rb
@@ -124,10 +124,11 @@ module Metar
       when @chunks[0] == 'AUTO' # WMO 15.4
         @chunks.shift
         @observer = :auto
-      when @chunks[0] == 'COR'
+      when @chunks[0] == 'COR'  # WMO specified code word for correction
         @chunks.shift
         @observer = :corrected
-      when @chunks[0] == 'CCA'
+      when @chunks[0] =~ /CC[A-Z]/  # Canadian correction
+        # Canada uses CCA for first correction, CCB for second, etc...
         @chunks.shift
         @observer = :corrected
       when @chunks[0] == 'RTD'   #  Delayed observation, no comments on observer

--- a/metar-parser.gemspec
+++ b/metar-parser.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'i18n', '>= 0.3.5'
   s.add_runtime_dependency 'm9t',  '~> 0.3.1'
 
-  s.add_development_dependency 'rspec',  '>= 2.11.0'
+  s.add_development_dependency 'rspec',  '~> 2.14.1'
   if RUBY_VERSION < '1.9'
     s.add_development_dependency 'rcov'
   else

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -92,8 +92,20 @@ describe Metar::Parser do
         expect(parser.observer).to eq(:corrected)
       end
 
-      it 'corrected (Canadian)' do
+      it 'corrected (Canadian, first correction)' do
         parser = setup_parser('CYZU 310100Z CCA 26004KT 15SM FEW009 BKN040TCU BKN100 OVC210 15/12 A2996 RETS RMK SF1TCU4AC2CI1 SLP149')
+
+        expect(parser.observer).to eq(:corrected)
+      end
+
+      it 'corrected (Canadian, second correction)' do
+        parser = setup_parser('CYCX 052000Z CCB 30014G27KT 15SM DRSN SCT035 M02/M09 A2992 RMK SC4 SLP133')
+
+        expect(parser.observer).to eq(:corrected)
+      end
+
+      it 'corrected (Canadian, rare third correction)' do
+        parser = setup_parser('CYEG 120000Z CCC 12005KT 15SM FEW110 BKN190 03/M01 A2980 RMK AC2AC3 SLP122')
 
         expect(parser.observer).to eq(:corrected)
       end


### PR DESCRIPTION
Canada uses CCA for the first correction, CCB for the second correction, etc. I updatef the parser to allow for this and added tests to cover CCB (less common) and CCC (rare). I also updated the gemspec to require RSpec 2.14.x as the tests need to be updated for RSpec 3.x.