### PR TITLE
Remove rake and rdoc gems from runtime dependencies.

### DIFF
--- a/metar-parser.gemspec
+++ b/metar-parser.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |s|
 
   s.test_files    = Dir.glob("spec/**/*_spec.rb")
 
-  s.add_runtime_dependency 'rake', '< 11.0'
-  s.add_runtime_dependency 'rdoc'
   s.add_runtime_dependency 'i18n', '~> 0.7.0'
   s.add_runtime_dependency 'm9t',  '~> 0.3.5'
 
@@ -38,6 +36,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
+  s.add_development_dependency 'rake', '< 11.0'
+  s.add_development_dependency 'rdoc'
 
   s.rubyforge_project = 'nowarning'
 end


### PR DESCRIPTION
The `rake` and `rdoc` gems aren't used at runtime, so they should be listed as development dependencies to avoid them getting pulled into production environments.