### PR TITLE
Ensure visibility units are accurately reported as meters.

### DIFF
--- a/lib/metar/data/visibility.rb
+++ b/lib/metar/data/visibility.rb
@@ -17,20 +17,17 @@ class Metar::Data::Visibility < Metar::Data::Base
     if m2
       miles          = m2[1].to_f + m2[3].to_f / m2[4].to_f
       distance       = Metar::Data::Distance.miles(miles)
-      distance.units = :miles
       return new(raw, distance: distance)
     end
 
     m3 = raw.match(/^(\d+)SM$/) # US
     if m3
       distance       = Metar::Data::Distance.miles(m3[1].to_f)
-      distance.units = :miles
       return new(raw, distance: distance)
     end
 
     if raw == 'M1/4SM' # US
       distance       = Metar::Data::Distance.miles(0.25)
-      distance.units = :miles
       return new(raw, distance: distance, comparator: :less_than)
     end
 

--- a/spec/data/visibility_spec.rb
+++ b/spec/data/visibility_spec.rb
@@ -19,6 +19,8 @@ RSpec::Matchers.define :be_visibility do |distance, direction, comparator|
       false
     elsif comparator.is_a?(Symbol)                   && visibility.comparator != comparator
       false
+    elsif visibility.distance.units != :meters
+      false
     else
       true
     end


### PR DESCRIPTION
Fixes #50.

The underlying m9t library automatically converts all units to meters, so specifying the distance unit as 'miles' results in a distance quantity in meters being reported as if it's in miles.

Added a sledgehammer spec as well.

It would be slightly nicer if m9t supported storing a distance with its unit, but since it auto-converts everything to meters, I think this is the best solution right now to ensure that this gem doesn't report a meters number with a miles unit attached to it.