### PR TITLE
Fix issue with long running connections.

### DIFF
--- a/lib/metar/raw.rb
+++ b/lib/metar/raw.rb
@@ -88,7 +88,7 @@ module Metar
         end
 
         def disconnect
-          return if @@connection.nil
+          return if @@connection.nil?
           @@connection.close
           @@connection = nil
         end
@@ -101,6 +101,7 @@ module Metar
               connection.retrbinary("RETR #{ cccc }.TXT", 1024) do |chunk|
                 s << chunk
               end
+              disconnect
               return s
             rescue Net::FTPPermError, Net::FTPTempError, EOFError => e
               connect


### PR DESCRIPTION
I use this gem in a long running weather script that I can ask for metar information. I noticed that if the time between requests is longer than 15 minutes, I get an error about the peer on the other end not being connected. It looks like the FTP connection to the NOAA site times out if it is idle for too long and the gem doesn't really know how to properly deal with this.

My fix is to have it disconnect the connection once it's done getting the metar data (line 104). I also corrected line 91 in the disconnect method.

--Chris Miconi