### PR TITLE
Don't raise an exception if a blank temperature or dewpoint is provided.

### DIFF
--- a/lib/metar/data/temperature.rb
+++ b/lib/metar/data/temperature.rb
@@ -4,6 +4,7 @@ require "m9t"
 # Adds a parse method to the M9t base class
 class Metar::Data::Temperature < M9t::Temperature
   def self.parse(raw)
+    return nil if !raw
     m = raw.match(/^(M?)(\d+)$/)
     return nil if !m
     sign = m[1]

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -275,9 +275,19 @@ describe Metar::Parser do
       expect(parser.temperature.value).to eq(-17)
     end
 
+    it "accepts a blank temperature" do
+      parser = setup_parser("KSMO 281655Z 18003KT 9SM SCT020 /20 A3002 RMK A02 T0200 $")
+      expect(parser.temperature).to eq(nil)
+    end
+
     it 'dew_point' do
       parser = setup_parser("PAIL 061610Z 24006KT 1 3/4SM -SN BKN016 OVC030 M17/M20 A2910 RMK AO2 P0000")
       expect(parser.dew_point.value).to eq(-20)
+    end
+
+    it "accepts a blank dew_point" do
+      parser = setup_parser("KSMO 281655Z 18003KT 9SM SCT020 20/ A3002 RMK A02 T0200 $")
+      expect(parser.dew_point).to eq(nil)
     end
 
     it 'sea_level_pressure' do


### PR DESCRIPTION
Prior to this change, attempting to parse this real example METAR threw an exception:
`KSMO 281655Z 18003KT 9SM SCTG020 20/ A3002 RMK A02 T0200 $`

```
NoMethodError: undefined method `match' for nil:NilClass 
metar-parser-1.4.3/lib/metar/data/temperature.rb:7→ parse
```

Open to other implementation suggestions. SMO in particular seems to throw one of these up at least once a day. 😢 