### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/metar-parser.gemspec
+++ b/metar-parser.gemspec
@@ -40,6 +40,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'timecop'
-
-  s.rubyforge_project = 'nowarning'
 end


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.