### PR TITLE
add support for parsing NSW for phenomenon

### DIFF
--- a/lib/metar/parser.rb
+++ b/lib/metar/parser.rb
@@ -282,6 +282,14 @@ module Metar
         end
       end
 
+      if @chunks[0] == 'NSW'
+        @present_weather << Metar::Data::WeatherPhenomenon.new(
+          nil, phenomenon: "no significant weather"
+        )
+        @chunks.shift
+        return
+      end
+
       loop do
         break if @chunks.empty?
         break if @chunks[0].start_with?("RE")

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -69,6 +69,7 @@ de:
     present_weather:
       title: Wetter
       not observed: nicht beobachtet
+      no significant weather: kein signifikantes Wetter
       mist: Nebel
       dust: Staub
       blowing dust: aufgewirbelter Staub

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -71,6 +71,7 @@ en:
     present_weather:
       title: weather
       not observed: not observed
+      no significant weather: no significant weather
       mist: mist
       dust: dust
       blowing dust: blowing dust

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -69,6 +69,7 @@ it:
     present_weather:
       title: tempo
       not observed: non osservato
+      no significant weather: nessun tempo significativo
       mist: foschia
       dust: polvere
       blowing dust: polviscolo

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -90,6 +90,7 @@ pt-BR:
     present_weather:
       title: clima
       not observed: não observado
+      no significant weather: sem clima significativo
       mist: misto
       dust: poeira
       blowing dust: sopro com poeira

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -305,6 +305,15 @@ describe Metar::Parser do
         expect(parser.present_weather.size).to eq(1)
         expect(parser.present_weather[0].phenomenon).to eq('not observed')
       end
+
+      it 'reports no significant weather' do
+        parser = setup_parser(
+          "LFSL 260630Z 31007KT 6000 NSW SCT018 BKN100 29/23 Q1010 NOSIG"
+        )
+
+        expect(parser.present_weather.size).to eq(1)
+        expect(parser.present_weather[0].phenomenon).to eq('no significant weather')
+      end
     end
 
     it 'present_weather_defaults_to_empty_array' do


### PR DESCRIPTION
Many stations prefer the use of NSW in the absence of any phenomenon but that acronym/keyword is not supported in the current codebase, which then results in an incomplete parse or a parsing failure.