### PR TITLE
Changing latitude parsing to set southern values to positive

### DIFF
--- a/lib/metar/station.rb
+++ b/lib/metar/station.rb
@@ -53,7 +53,7 @@ module Metar
         m = latitude.match(/^(\d+)-(\d+)([SN])/)
         return nil if !m
 
-        (m[3] == 'E' ? 1.0 : -1.0) * (m[1].to_f + m[2].to_f / 60.0)
+        (m[3] == 'S' ? 1.0 : -1.0) * (m[1].to_f + m[2].to_f / 60.0)
       end
     end
 

--- a/lib/metar/station.rb
+++ b/lib/metar/station.rb
@@ -53,7 +53,7 @@ module Metar
         m = latitude.match(/^(\d+)-(\d+)([SN])/)
         return nil if !m
 
-        (m[3] == 'S' ? 1.0 : -1.0) * (m[1].to_f + m[2].to_f / 60.0)
+        (m[3] == 'N' ? 1.0 : -1.0) * (m[1].to_f + m[2].to_f / 60.0)
       end
     end
 


### PR DESCRIPTION
Hello,

I was slightly confused when I realised that latitude never returned positive values, and places in the arctic regions were returning similar latitudes to those in Antarctica.  Literally a one character PR!

Actually having checked,  I think the convention is south is negative (as is west)